### PR TITLE
Add MaxUID parameter and fix connection error message

### DIFF
--- a/Application/modules/modbus/scanner/uid.py
+++ b/Application/modules/modbus/scanner/uid.py
@@ -20,7 +20,8 @@ class Module:
 		'RPORT'		:[502		,False	,'The port number for modbus protocol'],
 		'Function'	:[1		,False	,'Function code, Defualt:Read Coils.'],
 		'Threads'	:[1		,False	,'The number of concurrent threads'],
-		'Output'	:[True		,False	,'The stdout save in output directory']
+		'Output'	:[True		,False	,'The stdout save in output directory'],
+		'MaxUID'        :[255           ,False  ,'The maximum UID to check']
 	}	
 	output = ''
 
@@ -56,7 +57,7 @@ class Module:
 
 	def do(self,ip):
 		self.printLine('[+] Start Brute Force UID on : ' + ip,bcolors.OKGREEN)
-		for i in range(1,255): # Total of 255 (legal) uid
+		for i in range(1,self.options['MaxUID'][0]): # Total of 255 (legal) uid
 			c = connectToTarget(ip,self.options['RPORT'][0])
 			if(c == None):
 				break

--- a/System/Core/Modbus.py
+++ b/System/Core/Modbus.py
@@ -414,9 +414,8 @@ def connectToTarget(IP="127.0.0.1",port=modport):
 		s.connect((IP,int(port))) # encapsulate into try/catch
 		connection = StreamSocket(s,Raw)
 		return connection
-	except Exception,e:
-		print "Connection unsuccessful due to the following error :"
-		print e.message
+	except socket.error, e:
+		print "Connection unsuccessful due to the following error : %s" % (e)
 		return None
 def closeConnectionToTarget(c):
 	global connection


### PR DESCRIPTION
These commits make two substantial changes:

- Add a `MaxUID` parameter to the UID brute forcing module, allowing the tester to set the maximum UID to try
- Fixes an error in the Modbus module that prevented network error messages from displaying properly.